### PR TITLE
Shuffling words. Clarifying? You be the judge.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ A promise represents a value that may not be available yet. The primary method f
 
 ### Promise States
 
-1. A promise must be in one of three states: pending, fulfilled, or rejected.
+A promise must be in one of three states: pending, fulfilled, or rejected.
+
 1. When in pending, a promise:
     1. may transition to either the fulfilled or rejected state.
 1. When in fulfilled, a promise:


### PR DESCRIPTION
Moved the general description of what a promise is above the Terminology section, and broke up the requirements section into subsections for "The `then` Method" and "Promise Chaining".

Tried to clarify or simplify language, but may have only succeeded in making it more to my liking than generally _better_.
