### PR TITLE
Add normative text and supporting note for handler-returned promises

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,9 +63,10 @@ promise.then(onFulfilled, onRejected)
     ```
     1. If either `onFulfilled` or `onRejected` returns a value, `promise2` must be fulfilled with that value.
     1. If either `onFulfilled` or `onRejected` throws an exception, `promise2` must be rejected with the thrown exception as the reason.
-    1. If either `onFulfilled` or `onRejected` returns a promise (call it `returnedPromise`), `promise1.then` must attempt [[3](#notes)] to place `promise2` into the same state as `returnedPromise` by calling `returnedPromise.then(fulfillPromise2, rejectPromise2)`, where:
-        1. `fulfillPromise2` is a function which fulfills `promise2` with its first parameter.
-        1. `rejectPromise2` is a function which rejects `promise2` with its first parameter.
+    1. If either `onFulfilled` or `onRejected` returns a promise (call it `returnedPromise`), `promise2` must assume the state of `returnedPromise` [[3](#notes)]:
+        1. If `returnedPromise` is pending, `promise2` must remain pending until `returnedPromise` is fulfilled or rejected.
+        1. If/when `returnedPromise` is fulfilled, `promise2` must be fulfilled with the same value.
+        1. If/when `returnedPromise` is rejected, `promise2` must be rejected with the same reason.
     1. If `onFulfilled` is not a function and `promise1` is fulfilled, `promise2` must be fulfilled with the same value.
     1. If `onRejected` is not a function and `promise1` is rejected, `promise2` must be rejected with the same reason.
 
@@ -75,7 +76,11 @@ promise.then(onFulfilled, onRejected)
 
 1. Implementations may allow `promise2 === promise1`, provided the implementation meets all requirements. Each implementation should document whether it can produce `promise2 === promise1` and under what conditions.
 
-1. Given that `returnedPromise` may not be Promises/A+-compliant, but could instead be any object with a `then` method, it isn't always possible to fulfill the requirement of placing `promise2` in the same state as `returnedPromise`. Thus, the procedure here represents a best-faith effort.
+1. The mechanism by which `promise2` assumes the state of `returnedPromise` is not specified.  One reasonable approach is to call `returnedPromise.then(fulfillPromise2, rejectPromise2)`, where:
+    1. `fulfillPromise2` is a function which fulfills `promise2` with its first parameter.
+    1. `rejectPromise2` is a function which rejects `promise2` with its first parameter.
+
+    Given that `returnedPromise` may not be Promises/A+-compliant, but could instead be any object with a `then` method, it isn't always possible to satisfy the requirement of `promise2` assuming the same state as `returnedPromise`. Thus, the procedure here represents a best-faith effort.
 
 ---
 


### PR DESCRIPTION
This will probably conflict with #49, so either @lsmith or I will need to rebase.  Wanted to get feedback, though.
