### PR TITLE
Terminology clarification on "thenable" and "exception."

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,10 @@ A promise represents a value that may not be available yet. The primary method f
 
 ## Terminology
 
-1. "promise" is an object or function that defines a `then` method.
+1. "promise" is an object or function with a `then` method whose behavior conforms to this specification.
+1. "thenable" is an object or function that defines a `then` method.
 1. "value" is any legal JavaScript value (including `undefined` or a promise).
+1. "exception" is a value that is thrown using the `throw` statement.
 1. "reason" is a value that indicates why a promise was rejected.
 1. "must not change" means immutable identity (i.e. `===`), but does not imply deep immutability.
 
@@ -69,12 +71,12 @@ promise.then(onFulfilled, onRejected)
     promise2 = promise1.then(onFulfilled, onRejected);
     ```
 
-    1. If either `onFulfilled` or `onRejected` returns a value that is not a promise, `promise2` must be fulfilled with that value.
+    1. If either `onFulfilled` or `onRejected` returns a value that is not a thenable, `promise2` must be fulfilled with that value.
     1. If either `onFulfilled` or `onRejected` throws an exception, `promise2` must be rejected with the thrown exception as the reason.
-    1. If either `onFulfilled` or `onRejected` returns a promise (call it `returnedPromise`), `promise2` must assume the state of `returnedPromise` [[4.4](#notes)]:
-        1. If `returnedPromise` is pending, `promise2` must remain pending until `returnedPromise` is fulfilled or rejected.
-        1. If/when `returnedPromise` is fulfilled, `promise2` must be fulfilled with the same value.
-        1. If/when `returnedPromise` is rejected, `promise2` must be rejected with the same reason.
+    1. If either `onFulfilled` or `onRejected` returns a thenable (call it `returnedThenable`), `promise2` must attempt to adopt the state of `returnedThenable` under the assumption of it being a promise [[4.4](#notes)]:
+        1. If `returnedThenable` is pending, `promise2` must remain pending until `returnedThenable` is fulfilled or rejected.
+        1. If/when `returnedThenable` is fulfilled, `promise2` must be fulfilled with the same value.
+        1. If/when `returnedThenable` is rejected, `promise2` must be rejected with the same reason.
     1. If `onFulfilled` is not a function and `promise1` is fulfilled, `promise2` must be fulfilled with the same value.
     1. If `onRejected` is not a function and `promise1` is rejected, `promise2` must be rejected with the same reason.
 
@@ -86,11 +88,11 @@ promise.then(onFulfilled, onRejected)
 
 1. Implementations may allow `promise2 === promise1`, provided the implementation meets all requirements. Each implementation should document whether it can produce `promise2 === promise1` and under what conditions.
 
-1. The mechanism by which `promise2` assumes the state of `returnedPromise` is not specified.  One reasonable approach is to call `returnedPromise.then(fulfillPromise2, rejectPromise2)`, where:
+1. The mechanism by which `promise2` adopts the state of `returnedThenable` is not specified. One reasonable approach is to call `returnedThenable.then(fulfillPromise2, rejectPromise2)`, where:
     1. `fulfillPromise2` is a function which fulfills `promise2` with its first parameter.
     1. `rejectPromise2` is a function which rejects `promise2` with its first parameter.
 
-    Given that `returnedPromise` may not be Promises/A+-compliant, but could instead be any object with a `then` method, it isn't always possible to satisfy the requirement of `promise2` assuming the same state as `returnedPromise`. Thus, the procedure here represents a best-faith effort.
+    Given that `returnedThenable` may not be a promise, but could instead be any thenable, it isn't always possible to satisfy the requirement of `promise2` adopting the same state as `returnedThenable`. Thus, the procedure here represents a best-faith effort.
 
 ---
 


### PR DESCRIPTION
- Separate out "promise" and "thenable" concepts.
- Specify that "exception" just means "value".

The first of these helps greatly with the ambiguity of defining exactly what a promise is, versus the operational definition of a "thenable" as something that a promise consumes and assimilates if returned from a handler. The second helps clarify #65.
