### PR TITLE
Rephrase the way asynchronicity is mandated.

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ promise.then(onFulfilled, onRejected)
     1. it must be called after `promise` is rejected, with `promise`'s rejection reason as its first argument.
     1. it must not be called more than once.
     1. it must not be called if `onFulfilled` has been called.
-1. `then` must return before `onFulfilled` or `onRejected` is called [[4.1](#notes)].
+1. `onFulfilled` or `onRejected` may only be called when the function execution stack is empty [[4.1](#notes)].
 1. `then` may be called multiple times on the same promise.
     1. If/when `promise` is fulfilled, respective `onFulfilled` callbacks must execute in the order of their originating calls to `then`.
     1. If/when `promise` is rejected, respective `onRejected` callbacks must execute in the order of their originating calls to `then`.


### PR DESCRIPTION
As per conversations with MarkM, this is the real invariant we are trying to preserve: that the promise handlers cannot interleave with other code.
## 

This should probably be discussed, as it loses a bit in clarity I think. But, it is technically more correct than our current "`then` must return before `onFulfilled` or `onRejected` is called": if you imagined a hypothetical extended JavaScript that let you schedule operations to take place after you return and then three statements have executed, our current phrasing would allow that, which is not what we want. Or if you can imagine a hypothetical JavaScript that allows you to clear the current execution stack with some magic function, that would actually be a safe time to run the callbacks, even if it's before `then` returns.

BTW the concept of the execution stack is summarized in [section 10.3 of the ES5 spec](http://es5.github.com/#x10.3)
