### PR TITLE
Switch from "Thenable Assimilation Procedure" to "Promise Resolution Procedure"

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ To run `Resolve(promise, x)`, perform the following steps:
    1. If/when `x` is rejected, reject `promise` with the same reason.
 1. Otherwise, if `x` is an object or function,
    1. Let `then` be `x.then`. [[4.5](#notes)]
+   1. If retrieving the property `x.then` results in a thrown exception `e`, reject `promise` with `e` as the reason.
    1. If `then` is a function, call it with `x` as `this`, first argument `resolvePromise`, and second argument `rejectPromise`, where:
       1. If/when `resolvePromise` is called with a value `y`, run `Resolve(promise, y)`.
       1. If/when `rejectPromise` is called with a reason `r`, reject `promise` with `r`.


### PR DESCRIPTION
This was prompted by #87 and #88, and in particular the discussions about how you should only retrieve a reference to `then` once, and then call that same reference.

This necessitated refactoring from "if `x` is a thenable, run the `Assimilation(thenable, promise)`; otherwise, fulfill `promise` with `x`"---which necessarily seems to involve a two-step process---to simply "run `Resolve(promise, x)`." I think it turned out rather nicely, actually.

A second commit tries to resolve the question of exception handling by treating something with a throwing getter for `then` as a non-thenable. It seems right to me, but I am willing to be persuaded in the other direction. I included it as a separate commit specifically because the refactoring is separate from the exact approach of how we handle throwing getters for `then`.

You can see the end result [here](https://github.com/promises-aplus/promises-spec/blob/b312ea714ebae42fbe89892348abd348975cb558/README.md).
