### PR TITLE
Tweaks to [[Resolve]] for self-fulfillment and vicious cycles

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ This treatment of thenables allows promise implementations to interoperate, as l
 
 To run `[[Resolve]](promise, x)`, perform the following steps:
 
+1. If `promise` and `x` refer to the same object, reject `promise` with a `TypeError` as the reason.
 1. If `x` is a promise, adopt its state [[4.4](#notes)]:
    1. If `x` is pending, `promise` must remain pending until `x` is fulfilled or rejected.
    1. If/when `x` is fulfilled, fulfill `promise` with the same value.


### PR DESCRIPTION
The first commit fixes assimilation for thenables that fulfill with themselves, e.g. Q far references or Ember.js entity-promises.

The second commit allows, but does not require, detection of vicious cycles.

Practically, they mean the following. Given:

``` js
var a = {
  then(onFulfilled) { onFulfilled(a); }
};

var x = {
  then(onFulfilled) { onFulfilled(y); }
};

var y = {
  then(onFulfilled) { onFulfilled(x); }
};
```

Then:
- `[[Resolve]](p, a)` now results in `p` being fulfilled with `a`.
- `[[Resolve]](p, x)` is now allowed to result in `p` being rejected with an error, although this is not mandated and so infinite-looping is also allowed.
