### PR TITLE
Consistently use "reason" rather than "rejection reason"

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ promise.then(onFulfilled, onRejected)
     1. If `onFulfilled` is not a function, it must be ignored.
     1. If `onRejected` is not a function, it must be ignored.
 1. If `onFulfilled` is a function:
-    1. it must be called after `promise` is fulfilled, with `promise`'s fulfillment value as its first argument.
+    1. it must be called after `promise` is fulfilled, with `promise`'s value as its first argument.
     1. it must not be called more than once.
     1. it must not be called if `onRejected` has been called.
 1. If `onRejected` is a function,


### PR DESCRIPTION
See #80. We were mostly using "rejection reason" in the main part of the spec, but mostly using "reason" in the Resolution Procedure.  So, here's a shot at just using "reason" to see how people feel about it.  I think it reads well.
