### PR TITLE
fixed terminology

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,14 +93,14 @@ To run `[[Resolve]](promise, x)`, perform the following steps:
 1. Otherwise, if `x` is an object or function,
    1. Let `then` be `x.then`. [[4.5](#notes)]
    1. If retrieving the property `x.then` results in a thrown exception `e`, reject `promise` with `e` as the reason.
-   1. If `then` is a function, call it with `x` as `this`, first argument `resolvePromise`, and second argument `rejectPromise`, where:
-      1. If/when `resolvePromise` is called with a value `y`,
+   1. If `then` is a function, call it with `x` as `this`, first argument `fulfillPromise`, and second argument `rejectPromise`, where:
+      1. If/when `fulfillPromise` is called with a value `y`,
          1. If `x` and `y` refer to the same object, fulfill `promise` with `x`.
          1. Otherwise, run `[[Resolve]](promise, y)`.
       1. If/when `rejectPromise` is called with a reason `r`, reject `promise` with `r`.
-      1. If both `resolvePromise` and `rejectPromise` are called, or multiple calls to the same argument are made, the first call takes precedence, and any further calls are ignored.
+      1. If both `fulfillPromise` and `rejectPromise` are called, or multiple calls to the same argument are made, the first call takes precedence, and any further calls are ignored.
       1. If calling `then` throws an exception `e`,
-         1. If `resolvePromise` or `rejectPromise` have been called, ignore it.
+         1. If `fulfillPromise` or `rejectPromise` have been called, ignore it.
          1. Otherwise, reject `promise` with `e` as the reason.
    1. If `then` is not a function, fulfill `promise` with `x`.
 1. If `x` is not an object or function, fulfill `promise` with `x`.


### PR DESCRIPTION
changed name of the function being passed to thenables from `resolvePromise` to `fulfillPromise`
