### PR TITLE
Add Core to implementations list

### DIFF
--- a/implementations.md
+++ b/implementations.md
@@ -140,7 +140,7 @@ Conformant implementations are encouraged to include <a href="https://rawgithub.
             <td>Yet another Promises/A+ implementation</td>
         </tr>
         <tr>
-            <td><a href="https://github.com/sebastian-software/core">Core</a></td>
+            <td><a href="https://github.com/sebastian-software/core/blob/master/source/class/core/event/Promise.js">Core</a></td>
             <td>A Fine Foundation for JavaScript Projects</td>
         </tr>
     </tbody>


### PR DESCRIPTION
Core has a full spec compliant implementation of Promises/A+ in core.event.Promise.
