### PR TITLE
Thenable chains and circles

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ To run `[[Resolve]](promise, x)`, perform the following steps:
    1. If `then` is not a function, fulfill `promise` with `x`.
 1. If `x` is not an object or function, fulfill `promise` with `x`.
 
-Due to the recursive nature of this procedure, it is possible for a conformant implementation to cause infinite recursion if a promise is resolved with a thenable that participates in a circular thenable chain. Implementations are allowed, but not required, to detect such occurrences and instead reject `promise` with an informative `TypeError` as the reason.
+If a promise is resolved with a thenable that participates in a circular thenable chain, such that the recursive nature of `[[Resolve]](promise, thenable)` eventually causes `[[Resolve]](promise, thenable)` to be called again, following the above algorithm will lead to infinite recursion. Implementations are encouraged, but not required, to detect such recursion and reject `promise` with an informative `TypeError` as the reason.[[4.6](#notes)]
 
 ## Notes
 
@@ -114,6 +114,8 @@ Due to the recursive nature of this procedure, it is possible for a conformant i
 1. Generally, it will only be known that `x` is a true promise if it comes from the current implementation. This clause allows the use of implementation-specific means to adopt the state of known-conformant promises.
 
 1. This procedure of first storing a reference to `x.then`, then testing that reference, and then calling that reference, avoids multiple accesses to the `x.then` property. Such precautions are important for ensuring consistency in the face of an accessor property, whose value could change between retrievals.
+
+1. Implementations should *not* set arbitrary limits on the depth of thenable chains, and assume that beyond that arbitrary limit the recursion will be infinite. Only true cycles should lead to a `TypeError`; if an infinite chain of distinct thenables is encountered, recursing forever is the correct behavior.
 
 ---
 


### PR DESCRIPTION
As per discussions in #108, these commits:
- Remove the special case of self-fulfilling thenables, treating them as a one-cycle.
- Clarify that thenable _cycles_ are encouraged to cause a `TypeError`, but that infinite thenable _chains_ should recurse forever. This makes sense, because you can't detect infiniteness, so the only way to "detect" it would be to set an arbitrary limit and say "everything after 1000 is 'infinite'," which is bad.
