### PR TITLE
Encourage warning messages for `onFulfilled` or `onRejected` being promises

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ promise.then(onFulfilled, onRejected)
 ```
 
 1. Both `onFulfilled` and `onRejected` are optional arguments:
-    1. If `onFulfilled` is not a function, it must be ignored.
-    1. If `onRejected` is not a function, it must be ignored.
+    1. If `onFulfilled` is not a function, it must be ignored.  If `onFulfilled` is a promise, a warning message should be produced.
+    1. If `onRejected` is not a function, it must be ignored.  If `onRejected` is a promise, a warning message should be produced.
 1. If `onFulfilled` is a function:
     1. it must be called after `promise` is fulfilled, with `promise`'s value as its first argument.
     1. it must not be called before `promise` is fulfilled.


### PR DESCRIPTION
This is probably the most common error I see from beginners using promises on stack overflow (e.g. http://stackoverflow.com/questions/17517593/more-complex-deferred-promise-usage-and-chains-just-arent-clicking-would-love/17525172).  They call the function, rather than passing the function to `.then`.  Since I can't see why anyone would intentionally pass a promise to a `.then` handler and these sorts of functions almost always return promises, I think this could be a big win for helping people get started faster.

P.S. the PR is just there as a discussion point, I'm happy to re-word/move it as appropriate.
