### PR TITLE
Add tagline to spec to clarify that Promises/A+ is a JavaScript spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Promises/A+
 
+**An open standard for sound, interoperable JavaScript promises&mdash;by implementers, for implementers.**
+
 A *promise* represents the eventual result of an asynchronous operation. The primary way of interacting with a promise is through its `then` method, which registers callbacks to receive either a promise's eventual value or the reason why the promise cannot be fulfilled.
 
 This specification details the behavior of the `then` method, providing an interoperable base which all Promises/A+ conformant promise implementations can be depended on to provide. As such, the specification should be considered very stable. Although the Promises/A+ organization may occasionally revise this specification with minor backward-compatible changes to address newly-discovered corner cases, we will integrate large or backward-incompatible only after careful consideration, discussion, and testing.


### PR DESCRIPTION
Fix #135
