### PR TITLE
Link to ayepromise, a teeny-tiny promise library

### DIFF
--- a/implementations.md
+++ b/implementations.md
@@ -28,6 +28,9 @@ Also, if your implementation is published in the npm registry, we suggest using 
             <td>Example Promises/A+ implementation. Simple, tiny, fast, fully async</td>
         </tr>
         <tr>
+            <td><a href="https://github.com/cburgmer/ayepromise">ayepromise</a></td>
+            <td>A teeny-tiny promise library</td>
+        <tr>
             <td><a href="https://github.com/petkaantonov/bluebird">bluebird</a></td>
             <td>Full featured Promises/A+ implementation with exceptionally good performance</td>
         </tr>


### PR DESCRIPTION
[ayepromise](https://github.com/cburgmer/ayepromise), a teeny-tiny Promises/A+ 1.0 compliant promise library
