### PR TITLE
Moved library and updated

### DIFF
--- a/implementations.md
+++ b/implementations.md
@@ -65,9 +65,9 @@ Also, if your implementation is published in the npm registry, we suggest using 
             <td>1.0</td>
         </tr>
         <tr>
-            <td><a href="https://github.com/fidian/FidPromise">FidPromise</a></td>
+            <td><a href="https://github.com/tests-always-included/fid-promise">FidPromise</a></td>
             <td>Promise implementation that is readable and debuggable</td>
-            <td>1.0</td>
+            <td>1.1</td>
         </tr>
         <tr>
             <td><a href="https://github.com/novemberborn/legendary">Legendary</a></td>


### PR DESCRIPTION
The library now has a new home in GitHub.

Part of the move involves making the updated test suite work, so now it passes against the tests - v2.0.4.
