### PR TITLE
Clarify value/reason propagation

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,8 +69,8 @@ promise.then(onFulfilled, onRejected)
 
     1. If either `onFulfilled` or `onRejected` returns a value `x`, run the Promise Resolution Procedure `[[Resolve]](promise2, x)`.
     1. If either `onFulfilled` or `onRejected` throws an exception `e`, `promise2` must be rejected with `e` as the reason.
-    1. If `onFulfilled` is not a function and `promise1` is fulfilled, `promise2` must be fulfilled with the same value.
-    1. If `onRejected` is not a function and `promise1` is rejected, `promise2` must be rejected with the same reason.
+    1. If `onFulfilled` is not a function and `promise1` is fulfilled, `promise2` must be fulfilled with the same value as `promise1`.
+    1. If `onRejected` is not a function and `promise1` is rejected, `promise2` must be rejected with the same reason as `promise1`.
 
 ### The Promise Resolution Procedure
 


### PR DESCRIPTION
Specifically, add clause to clarify when onFulfilled/onRejected are
not functions, promise1's value/reason must be propagated.

Thanks, @getify. See twitter convo:
https://twitter.com/getify/status/463297602084032513
