### PR TITLE
Add another Promise polyfill

### DIFF
--- a/implementations.md
+++ b/implementations.md
@@ -110,6 +110,11 @@ Also, if your implementation is published in the npm registry, we suggest using 
             <td>1.1</td>
         </tr>
         <tr>
+            <td><a href="https://github.com/Octane/Promise">Octane/Promise</a></td>
+            <td>Promises/A+ compliant implementation of ES6 promises for browsers and Node.js</td>
+            <td>1.1</td>
+        </tr>
+        <tr>
             <td><a href="https://github.com/ondras/promise">ondras/promise</a></td>
             <td>Straightforward client-side Promises/A+ implementation, with XHR, setTimeout etc.</td>
             <td>1.1</td>


### PR DESCRIPTION
The [Promise polyfill](https://github.com/Octane/Promise) is passing 872 tests of the [Promises/A+ compliance test suite](https://github.com/promises-aplus/promises-tests) [![Build Status](https://travis-ci.org/Octane/Promise.svg?branch=master)](https://travis-ci.org/Octane/Promise)

![passing 872 tests](https://dl.dropboxusercontent.com/u/8763532/screenshots/promise872tests.png)
try it
```
$ git clone https://github.com/Octane/Promise.git
$ cd Promise
$ npm install
$ npm test
```

I wasn't trying to run mocha-based Promise/A+ tests in a browser, but I have [55 browser-based tests](https://octane.github.io/promise/tests/browser.html)  in which there are tests for `Promise.all` and `Promise.race` (missing in the test suite).

Supports IE8+