### PR TITLE
Add Yaku to implementation list

### DIFF
--- a/implementations.md
+++ b/implementations.md
@@ -240,6 +240,11 @@ Also, if your implementation is published in the npm registry, we suggest using 
             <td>1.1</td>
         </tr>
         <tr>
+            <td><a href="https://github.com/ysmood/yaku">yaku</a></td>
+            <td>A fast, lightweight, error friendly and ES6 compatible implementation (~3.5KB)</td>
+            <td>1.1</td>
+        </tr>
+        <tr>
             <td><a href="https://github.com/jharding/yapa">yapa</a></td>
             <td>Yet another Promises/A+ implementation</td>
             <td>1.0</td>


### PR DESCRIPTION
[Yaku](https://github.com/ysmood/yaku) passed all the test of https://github.com/promises-aplus/promises-tests.
To test it:
```
git clone https://github.com/ysmood/yaku.git
cd yaku
npm install
npm test
```

You can also check it on its [travis-ci page](https://travis-ci.org/ysmood/yaku/jobs/71827140).