### PR TITLE
Added a PHP Promises/A+ implementation to the list

### DIFF
--- a/implementations.md
+++ b/implementations.md
@@ -389,5 +389,10 @@ We've been excited to discover that the popularity of Promises/A+ has led to a n
             <td><a href="https://github.com/Real-Serious-Games/c-sharp-promise">Real-Serious-Games/c-sharp-promise</a></td>
             <td>An unit-tested implementation of the Promises/A+ pattern for asynchronous programming in C#.</td>
         </tr>
+        <tr>
+            <td>PHP</td>
+            <td><a href="https://github.com/guzzle/promises">Guzzle Promises</a></td>
+            <td>Promises/A+ implementation in PHP that handles promise chaining and resolution iteratively, allowing for "infinite" promise chaining, while keeping the stack size constant.</td>
+        </tr>
     </tbody>
 </table>


### PR DESCRIPTION
[Guzzle](http://guzzlephp.org/), an HTTP client for PHP, has a very nice [PHP Promises/A+ library](https://github.com/guzzle/promises) that it uses to help provide its asynchronous features. It would be cool if it was added to the "In Other Languages" list on your implementations page.