### PR TITLE
Add Java implementation to Other Languages section

### DIFF
--- a/implementations.md
+++ b/implementations.md
@@ -485,5 +485,10 @@ We've been excited to discover that the popularity of Promises/A+ has led to a n
             <td><a href="https://github.com/guzzle/promises">Guzzle Promises</a></td>
             <td>Promises/A+ implementation in PHP that handles promise chaining and resolution iteratively, allowing for "infinite" promise chaining, while keeping the stack size constant.</td>
         </tr>
+        <tr>
+            <td>Java</td>
+            <td><a href="https://github.com/ioweyou/iou-java">IOU</a></td>
+            <td>Promises/A+ for Java and <a href="https://github.com/ioweyou/iou-android">Android</a></td>
+        </tr>
     </tbody>
 </table>


### PR DESCRIPTION
This commit adds my IOU library as a Java (and Android) implementation to the Other Languages section. The Promises/A+ test set is implemented in https://github.com/ioweyou/iou-core and verified by https://travis-ci.org/ioweyou/iou-core