### PR TITLE
fix: 2.3.3.3.4.1: be specific about what to ignore

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ To run `[[Resolve]](promise, x)`, perform the following steps:
       1. If/when `rejectPromise` is called with a reason `r`, reject `promise` with `r`.
       1. If both `resolvePromise` and `rejectPromise` are called, or multiple calls to the same argument are made, the first call takes precedence, and any further calls are ignored.
       1. If calling `then` throws an exception `e`,
-         1. If `resolvePromise` or `rejectPromise` have been called, ignore it.
+         1. If `resolvePromise` or `rejectPromise` have been called, ignore `e`.
          1. Otherwise, reject `promise` with `e` as the reason.
    1. If `then` is not a function, fulfill `promise` with `x`.
 1. If `x` is not an object or function, fulfill `promise` with `x`.


### PR DESCRIPTION
When I read "it", I wrongly thought "it" refers to either
`resolvePromise` or `rejectPromise`.

This change should prevent the next possible confusion.

Closes #265